### PR TITLE
feat(SHAR-332): allow auth0 service-to-service authentication

### DIFF
--- a/src/BrighteApi.php
+++ b/src/BrighteApi.php
@@ -113,6 +113,7 @@ class BrighteApi
             $this->accessTokens[$audience] = $accessToken->get();
             if ($this->accessTokens[$audience]) {
                 $this->logger->debug("Fetched Service JWT from cache");
+                $this->accessToken = $this->accessTokens[$audience];
                 return;
             }
         }

--- a/src/BrighteApi.php
+++ b/src/BrighteApi.php
@@ -79,16 +79,8 @@ class BrighteApi
         array $config,
         ?CacheItemPoolInterface $cache
     ) {
-        $uri = new Uri($config['uri']);
-        $uriAuth0 = new Uri('https://' . $config['auth0_domain']);
-        $this->scheme[self::BRIGHTE_API] = $uri->getScheme();
-        $this->host[self::BRIGHTE_API] = $uri->getHost();
-        $this->prefix[self::BRIGHTE_API] = $uri->getPath();
-        $this->port[self::BRIGHTE_API] = $uri->getPort();
-        $this->scheme[self::AUTH0] = $uriAuth0->getScheme();
-        $this->host[self::AUTH0] = $uriAuth0->getHost();
-        $this->prefix[self::AUTH0] = $uriAuth0->getPath();
-        $this->port[self::AUTH0] = $uriAuth0->getPort();
+        $this->setUri($config['uri'], self::BRIGHTE_API);
+        $this->setUri('https://' . $config['auth0_domain'], self::AUTH0);
         $this->clientId = $config['client_id'] ?? null;
         $this->clientSecret = $config['client_secret'] ?? null;
         $this->apiKey = $config['key'] ?? null;
@@ -311,7 +303,7 @@ class BrighteApi
             $headers['Authorization'] = 'Bearer ' . $this->getToken($audience);
         }
 
-        $path = UriResolver::removeDotSegments($this->prefix . $path);
+        $path = UriResolver::removeDotSegments($this->prefix[$service] . $path);
 
         return  $this->http->sendRequest(new Request(
             $method,
@@ -374,5 +366,14 @@ class BrighteApi
     private static function cleanAudience(string $audience): string
     {
         return str_replace(['https://', '/'], ['', '_'], $audience);
+    }
+
+    private function setUri($uri, $service): void
+    {
+        $uri = new Uri($uri);
+        $this->scheme[$service] = $uri->getScheme();
+        $this->host[$service] = $uri->getHost();
+        $this->prefix[$service] = $uri->getPath();
+        $this->port[$service] = $uri->getPort();
     }
 }

--- a/src/BrighteApi.php
+++ b/src/BrighteApi.php
@@ -291,7 +291,7 @@ class BrighteApi
         ?string $body,
         array $headers,
         string $audience = null,
-        string $service = self::BRIGHTE_API,
+        string $service = self::BRIGHTE_API
     ): ResponseInterface {
         $this->logger->debug(
             'BrighteApi->' . __FUNCTION__,

--- a/src/BrighteApi.php
+++ b/src/BrighteApi.php
@@ -48,6 +48,9 @@ class BrighteApi
     /** @var string accessToken */
     protected $accessToken;
 
+    /** @var string brighteUri */
+    protected $brighteUri;
+
     /** @var string[] accessTokens */
     protected $accessTokens = [];
 
@@ -79,8 +82,6 @@ class BrighteApi
         array $config,
         ?CacheItemPoolInterface $cache
     ) {
-        $this->setUri($config['uri'], self::BRIGHTE_API);
-        $this->setUri('https://' . $config['auth0_domain'], self::AUTH0);
         $this->clientId = $config['client_id'] ?? null;
         $this->clientSecret = $config['client_secret'] ?? null;
         $this->apiKey = $config['key'] ?? null;
@@ -88,6 +89,9 @@ class BrighteApi
         $this->logger = $log;
         $this->cacheItemPool = $cache;
         $this->jwtCacheKey = $this->clientId . '_' . self::JWT_SERVICE_CACHE_KEY;
+        $this->brighteUri = $config['uri'];
+        $this->setUri($this->brighteUri, self::BRIGHTE_API);
+        $this->setUri('https://' . $config['auth0_domain'], self::AUTH0);
     }
 
     public function getToken(string $audience): string
@@ -124,7 +128,7 @@ class BrighteApi
                 'client_id' => $this->clientId,
                 'client_secret' => $this->clientSecret,
                 'grant_type' => 'client_credentials',
-                'audience' => $audience,
+                'audience' => $this->brighteUri . UriResolver::removeDotSegments($this->prefix[self::BRIGHTE_API] . $audience),
             ];
             $authBody = \json_encode($options);
             $response = $this->post($authPath, $authBody, '', [], null, self::AUTH0);

--- a/src/BrighteApi.php
+++ b/src/BrighteApi.php
@@ -365,7 +365,7 @@ class BrighteApi
      * @param string|null $audience
      * @return string|null
      */
-    private function buildAudience($audience): string|null
+    private function buildAudience($audience): ?string
     {
         if ($audience === null) {
             return null;

--- a/src/BrighteApi.php
+++ b/src/BrighteApi.php
@@ -125,7 +125,7 @@ class BrighteApi
                 'client_id' => $this->clientId,
                 'client_secret' => $this->clientSecret,
                 'grant_type' => 'client_credentials',
-                'audience' => $this->buildAudience($audience),
+                'audience' => $audience,
             ];
             $authBody = \json_encode($options);
             $response = $this->post($authPath, $authBody, '', [], null, self::AUTH0);
@@ -158,7 +158,7 @@ class BrighteApi
      * @param string $path
      * @param string $query
      * @param string[] $headers
-     * @param string|null $audience
+     * @param string|null $audiencePath
      * @param string $service
      * @return \Psr\Http\Message\ResponseInterface
      **/
@@ -166,9 +166,10 @@ class BrighteApi
         string $path,
         string $query = '',
         array $headers = [],
-        string $audience = null,
+        string $audiencePath = null,
         string $service = self::BRIGHTE_API
     ): ResponseInterface {
+        $audience = $this->buildAudience($audiencePath);
         return $this->getCached(
             $path . '?' . $query,
             [$this, 'doRequest'],
@@ -201,7 +202,7 @@ class BrighteApi
      * @param string $body
      * @param string $query
      * @param string[] $headers
-     * @param string|null $audience
+     * @param string|null $audiencePath
      * @param string $service
      * @return \Psr\Http\Message\ResponseInterface
      **/
@@ -210,9 +211,10 @@ class BrighteApi
         string $body,
         string $query = '',
         array $headers = [],
-        string $audience = null,
+        string $audiencePath = null,
         string $service = self::BRIGHTE_API
     ): ResponseInterface {
+        $audience = $this->buildAudience($audiencePath);
         return $this->doRequest('POST', $path, $query, $body, $headers, $audience, $service);
     }
 
@@ -223,7 +225,7 @@ class BrighteApi
         string $body,
         string $query = '',
         array $headers = [],
-        string $audience = null
+        string $audiencePath = null
     ) {
         $key = implode('_', [$functionName, implode('_', $parameters)]);
         if (array_key_exists($key, $this->cache)) {
@@ -233,6 +235,7 @@ class BrighteApi
             return $this->cacheItemPool->getItem($key)->get();
         }
 
+        $audience = $this->buildAudience($audiencePath);
         $response = $this->doRequest('POST', $path, $query, $body, $headers, $audience);
 
         $responseBody = $this->checkIfContainsError($functionName, $response);
@@ -359,11 +362,14 @@ class BrighteApi
     }
 
     /**
-     * @param string $audience
-     * @return string
+     * @param string|null $audience
+     * @return string|null
      */
-    private function buildAudience($audience): string
+    private function buildAudience($audience): string|null
     {
+        if ($audience === null) {
+            return null;
+        }
         $path = UriResolver::removeDotSegments($this->prefix[self::BRIGHTE_API] . $audience);
         return $this->scheme[self::BRIGHTE_API] . '://' . $this->host[self::BRIGHTE_API] . $path;
     }

--- a/src/BrighteApi.php
+++ b/src/BrighteApi.php
@@ -362,15 +362,15 @@ class BrighteApi
     }
 
     /**
-     * @param string|null $audience
+     * @param string|null $audiencePath
      * @return string|null
      */
-    private function buildAudience($audience): ?string
+    private function buildAudience($audiencePath): ?string
     {
-        if ($audience === null) {
+        if ($audiencePath === null) {
             return null;
         }
-        $path = UriResolver::removeDotSegments($this->prefix[self::BRIGHTE_API] . $audience);
+        $path = UriResolver::removeDotSegments($this->prefix[self::BRIGHTE_API] . $audiencePath);
         return $this->scheme[self::BRIGHTE_API] . '://' . $this->host[self::BRIGHTE_API] . $path;
     }
 

--- a/src/BrighteApi.php
+++ b/src/BrighteApi.php
@@ -18,6 +18,8 @@ class BrighteApi
 {
     public const ERROR_FIELD_NAME_IN_JSON = 'errors';
     public const JWT_SERVICE_CACHE_KEY = 'service_jwt';
+    public const AUTH0 = 'auth0';
+    public const BRIGHTE_API = 'brighteApi';
 
     /** @var string|null */
     public $clientId;
@@ -25,17 +27,17 @@ class BrighteApi
     /** @var string|null */
     public $clientSecret;
 
-    /** @var string scheme */
-    protected $scheme;
+    /** @var string[] scheme */
+    protected $scheme = [];
 
-    /** @var string host */
-    protected $host;
+    /** @var string[] host */
+    protected $host = [];
 
-    /** @var string prefix */
-    protected $prefix;
+    /** @var string[] prefix */
+    protected $prefix = [];
 
-    /** @var int port */
-    protected $port;
+    /** @var int[] port */
+    protected $port = [];
 
     /**
      * @deprecated please don't use this anymore
@@ -45,6 +47,9 @@ class BrighteApi
 
     /** @var string accessToken */
     protected $accessToken;
+
+    /** @var string[] accessTokens */
+    protected $accessTokens = [];
 
     /** @var \Psr\Http\Client\ClientInterface HTTP client */
     protected $http;
@@ -75,10 +80,15 @@ class BrighteApi
         ?CacheItemPoolInterface $cache
     ) {
         $uri = new Uri($config['uri']);
-        $this->scheme = $uri->getScheme();
-        $this->host = $uri->getHost();
-        $this->prefix = $uri->getPath();
-        $this->port = $uri->getPort();
+        $uriAuth0 = new Uri('https://' . $config['auth0_domain']);
+        $this->scheme[self::BRIGHTE_API] = $uri->getScheme();
+        $this->host[self::BRIGHTE_API] = $uri->getHost();
+        $this->prefix[self::BRIGHTE_API] = $uri->getPath();
+        $this->port[self::BRIGHTE_API] = $uri->getPort();
+        $this->scheme[self::AUTH0] = $uriAuth0->getScheme();
+        $this->host[self::AUTH0] = $uriAuth0->getHost();
+        $this->prefix[self::AUTH0] = $uriAuth0->getPath();
+        $this->port[self::AUTH0] = $uriAuth0->getPort();
         $this->clientId = $config['client_id'] ?? null;
         $this->clientSecret = $config['client_secret'] ?? null;
         $this->apiKey = $config['key'] ?? null;
@@ -88,26 +98,28 @@ class BrighteApi
         $this->jwtCacheKey = $this->clientId . '_' . self::JWT_SERVICE_CACHE_KEY;
     }
 
-    public function getToken(): string
+    public function getToken(string $audience): string
     {
+        $this->accessToken = $this->accessTokens[$audience] ?? null;
         if ($this->accessToken) {
-            if (!$this->isTokenExpired($this->accessToken)) {
+            if (!self::isTokenExpired($this->accessToken)) {
                 return $this->accessToken;
             }
 
-            $this->cacheItemPool->deleteItem($this->jwtCacheKey);
+            $this->cacheItemPool->deleteItem($this->jwtCacheKey . '_' . self::cleanAudience($audience));
         }
 
-        $this->authenticate();
+        $this->authenticate($audience);
 
         return $this->accessToken;
     }
 
-    protected function authenticate(): void
+    protected function authenticate(string $audience): void
     {
-        if ($this->cacheItemPool && $accessToken = $this->cacheItemPool->getItem($this->jwtCacheKey)) {
-            $this->accessToken = $accessToken->get();
-            if ($this->accessToken) {
+
+        if ($this->cacheItemPool && $accessToken = $this->cacheItemPool->getItem($this->jwtCacheKey . '_' . self::cleanAudience($audience))) {
+            $this->accessTokens[$audience] = $accessToken->get();
+            if ($this->accessTokens[$audience]) {
                 $this->logger->debug("Fetched Service JWT from cache");
                 return;
             }
@@ -115,18 +127,21 @@ class BrighteApi
 
         $this->logger->info("Not authenticated with Brighte APIs, authenticating");
         if ($this->clientId && $this->clientSecret) {
-            $authPath = '/identity/token';
+            $authPath = '/oauth/token';
             $options = [
                 'client_id' => $this->clientId,
                 'client_secret' => $this->clientSecret,
                 'grant_type' => 'client_credentials',
+                'audience' => $audience,
             ];
             $authBody = \json_encode($options);
+            $response = $this->post($authPath, $authBody, '', [], null, self::AUTH0);
         } else {
             $authPath = '/identity/authenticate';
             $authBody = json_encode(['apiKey' => $this->apiKey]);
+            $response = $this->post($authPath, $authBody, '', [], null, self::BRIGHTE_API);
         }
-        $response = $this->post($authPath, $authBody, '', [], false);
+
         $body = json_decode((string) $response->getBody());
 
         if ($response->getStatusCode() !== StatusCodeInterface::STATUS_OK) {
@@ -136,7 +151,7 @@ class BrighteApi
         $this->accessToken = $body->access_token ?? $body->accessToken;
 
         if ($this->cacheItemPool) {
-            $item = $this->cacheItemPool->getItem($this->jwtCacheKey);
+            $item = $this->cacheItemPool->getItem($this->jwtCacheKey . '_' . self::cleanAudience($audience));
             $item->set($this->accessToken);
             $expires = $body->expires_in ?? null;
             $expires = (int) $expires ?: new \DateInterval('PT' . strtoupper($expires ?: "15m"));
@@ -150,15 +165,21 @@ class BrighteApi
      * @param string $path
      * @param string $query
      * @param string[] $headers
-     * @param bool $auth use authentication?
+     * @param string|null $audience
+     * @param string $service
      * @return \Psr\Http\Message\ResponseInterface
      **/
-    public function get(string $path, string $query = '', array $headers = [], bool $auth = true): ResponseInterface
-    {
+    public function get(
+        string $path,
+        string $query = '',
+        array $headers = [],
+        string $audience = null,
+        string $service = self::BRIGHTE_API
+    ): ResponseInterface {
         return $this->getCached(
             $path . '?' . $query,
             [$this, 'doRequest'],
-            ['GET', $path, $query, null, $headers, $auth]
+            ['GET', $path, $query, null, $headers, $audience, $service]
         );
     }
 
@@ -187,7 +208,8 @@ class BrighteApi
      * @param string $body
      * @param string $query
      * @param string[] $headers
-     * @param bool $auth use authentication?
+     * @param string|null $audience
+     * @param string $service
      * @return \Psr\Http\Message\ResponseInterface
      **/
     public function post(
@@ -195,9 +217,10 @@ class BrighteApi
         string $body,
         string $query = '',
         array $headers = [],
-        bool $auth = true
+        string $audience = null,
+        string $service = self::BRIGHTE_API
     ): ResponseInterface {
-        return $this->doRequest('POST', $path, $query, $body, $headers, $auth);
+        return $this->doRequest('POST', $path, $query, $body, $headers, $audience, $service);
     }
 
     public function cachedPost(
@@ -207,7 +230,7 @@ class BrighteApi
         string $body,
         string $query = '',
         array $headers = [],
-        bool $auth = true
+        string $audience = null
     ) {
         $key = implode('_', [$functionName, implode('_', $parameters)]);
         if (array_key_exists($key, $this->cache)) {
@@ -217,7 +240,7 @@ class BrighteApi
             return $this->cacheItemPool->getItem($key)->get();
         }
 
-        $response = $this->doRequest('POST', $path, $query, $body, $headers, $auth);
+        $response = $this->doRequest('POST', $path, $query, $body, $headers, $audience);
 
         $responseBody = $this->checkIfContainsError($functionName, $response);
         if ($responseBody === null) {
@@ -261,7 +284,8 @@ class BrighteApi
      * @param string $query
      * @param string|null $body
      * @param string[] $headers
-     * @param bool $auth use authentication?
+     * @param string|null $audience
+     * @param string $service
      * @return \Psr\Http\Message\ResponseInterface
      **/
     protected function doRequest(
@@ -270,7 +294,8 @@ class BrighteApi
         string $query,
         ?string $body,
         array $headers,
-        bool $auth = true
+        string $audience = null,
+        string $service = self::BRIGHTE_API,
     ): ResponseInterface {
         $this->logger->debug(
             'BrighteApi->' . __FUNCTION__,
@@ -282,8 +307,8 @@ class BrighteApi
             'accept' => 'application/json',
         ], $headers);
 
-        if ($auth) {
-            $headers['Authorization'] = 'Bearer ' . $this->getToken();
+        if ($audience) {
+            $headers['Authorization'] = 'Bearer ' . $this->getToken($audience);
         }
 
         $path = UriResolver::removeDotSegments($this->prefix . $path);
@@ -291,9 +316,9 @@ class BrighteApi
         return  $this->http->sendRequest(new Request(
             $method,
             Uri::fromParts([
-                'scheme' => $this->scheme,
-                'host' => $this->host,
-                'port' => $this->port,
+                'scheme' => $this->scheme[$service],
+                'host' => $this->host[$service],
+                'port' => $this->port[$service],
                 'path' => $path,
                 'query' => $query,
             ]),
@@ -306,12 +331,12 @@ class BrighteApi
      * @param string $token
      * @return bool
      */
-    private function isTokenExpired(string $token): bool
+    private static function isTokenExpired(string $token): bool
     {
         $bufferInSeconds = 3;
 
         $currentTimestamp = time();
-        $decoded = $this->decodeToken($token);
+        $decoded = self::decodeToken($token);
 
         return $currentTimestamp > ($decoded->exp - $bufferInSeconds);
     }
@@ -320,7 +345,7 @@ class BrighteApi
      * @param string $token
      * @return \stdClass
      */
-    private function decodeToken(string $token): \stdClass
+    private static function decodeToken(string $token): \stdClass
     {
         $tokenPayload = explode(".", $token)[1];
 
@@ -338,5 +363,16 @@ class BrighteApi
             $body->errors[0]->message ?? $response->getReasonPhrase()
         );
         $this->logger->warning($message);
+    }
+
+    /**
+     * Remove any invalid characters for cache key
+     * message: key contains one or more characters reserved for future extension: {}()/\\@:
+     * @param string $audience
+     * @return string
+     */
+    private static function cleanAudience(string $audience): string
+    {
+        return str_replace(['https://', '/'], ['', '_'], $audience);
     }
 }

--- a/src/CommunicationApi.php
+++ b/src/CommunicationApi.php
@@ -20,7 +20,7 @@ class CommunicationApi extends \BrighteCapital\Api\AbstractApi
             'payload' => $notification->payload ?: null,
         ]);
 
-        $response = $this->brighteApi->post(sprintf('%s/notifications', self::PATH), $body);
+        $response = $this->brighteApi->post(sprintf('%s/notifications', self::PATH), $body, '', [], self::PATH);
 
         if ($response->getStatusCode() !== StatusCodeInterface::STATUS_CREATED) {
             $this->logResponse(__FUNCTION__, $response);

--- a/src/FinanceCoreApi.php
+++ b/src/FinanceCoreApi.php
@@ -30,7 +30,7 @@ class FinanceCoreApi extends \BrighteCapital\Api\AbstractApi
             json_encode($requestBody),
             '',
             [],
-            true
+            self::PATH
         );
 
         if ($responseBody == null) {
@@ -56,7 +56,7 @@ class FinanceCoreApi extends \BrighteCapital\Api\AbstractApi
             json_encode($requestBody),
             '',
             [],
-            true
+            self::PATH
         );
 
         if ($responseBody == null) {
@@ -168,7 +168,7 @@ GQL;
             json_encode($requestBody),
             '',
             [],
-            true
+            self::PATH
         );
 
         if ($responseBody == null) {
@@ -232,7 +232,7 @@ GQL;
             json_encode($requestBody),
             '',
             [],
-            true
+            self::PATH
         );
 
         if ($responseBody == null) {
@@ -309,7 +309,7 @@ GQL;
             json_encode($requestBody),
             '',
             [],
-            true
+            self::PATH
         );
 
         if ($responseBody == null) {
@@ -372,7 +372,7 @@ GQL;
             json_encode($requestBody),
             '',
             [],
-            true
+            self::PATH
         );
 
         if ($responseBody == null) {

--- a/src/IdentityApi.php
+++ b/src/IdentityApi.php
@@ -17,13 +17,13 @@ class IdentityApi extends \BrighteCapital\Api\AbstractApi
     public function getUser(int $userId): ?User
     {
         $response = $this->brighteApi->get(sprintf('%s/users/%d', self::PATH, $userId), '', [], self::PATH);
-        
+
         if ($response->getStatusCode() !== StatusCodeInterface::STATUS_OK) {
             $this->logResponse(__FUNCTION__, $response);
 
             return null;
         }
-        
+
         $result = json_decode((string) $response->getBody());
 
         $user = new User();
@@ -51,13 +51,13 @@ class IdentityApi extends \BrighteCapital\Api\AbstractApi
         ]);
 
         $response = $this->brighteApi->post(sprintf('%s/users', self::PATH), $body, '', [], self::PATH);
-        
+
         if ($response->getStatusCode() !== StatusCodeInterface::STATUS_OK) {
             $this->logResponse(__FUNCTION__, $response);
 
             return null;
         }
-        
+
         $result = json_decode((string) $response->getBody());
 
         $user->id = (int) $result->id ?? null;
@@ -70,18 +70,17 @@ class IdentityApi extends \BrighteCapital\Api\AbstractApi
         $body = \json_encode([
             'grant_type' => 'authorization_code',
             'code' => $code,
-            // need to revisit this as the clientId has changed to auth0
             'client_id' => $this->brighteApi->clientId
         ]);
 
         $response = $this->brighteApi->post(sprintf('%s/token', self::PATH), $body, '', [], self::PATH);
-        
+
         if ($response->getStatusCode() !== StatusCodeInterface::STATUS_OK) {
             $this->logResponse(__FUNCTION__, $response);
 
             throw new AuthenticationFailedException(\json_decode((string) $response->getBody())->error);
         }
-        
+
         $result = json_decode((string) $response->getBody());
 
         return new IdentityTokenResponse(
@@ -97,13 +96,13 @@ class IdentityApi extends \BrighteCapital\Api\AbstractApi
         $body = \json_encode(['refreshToken' => $refreshToken]);
 
         $response = $this->brighteApi->post(sprintf('%s/refresh', self::PATH), $body, '', [], self::PATH);
-        
+
         if ($response->getStatusCode() !== StatusCodeInterface::STATUS_OK) {
             $this->logResponse(__FUNCTION__, $response);
 
             throw new AuthenticationFailedException(\json_decode((string) $response->getBody())->code);
         }
-        
+
         $result = json_decode((string) $response->getBody());
 
         return new IdentityTokenResponse(

--- a/src/IdentityApi.php
+++ b/src/IdentityApi.php
@@ -16,7 +16,7 @@ class IdentityApi extends \BrighteCapital\Api\AbstractApi
 
     public function getUser(int $userId): ?User
     {
-        $response = $this->brighteApi->get(sprintf('%s/users/%d', self::PATH, $userId));
+        $response = $this->brighteApi->get(sprintf('%s/users/%d', self::PATH, $userId), '', [], self::PATH);
         
         if ($response->getStatusCode() !== StatusCodeInterface::STATUS_OK) {
             $this->logResponse(__FUNCTION__, $response);
@@ -50,7 +50,7 @@ class IdentityApi extends \BrighteCapital\Api\AbstractApi
             'lastName' => $user->lastName ?? '',
         ]);
 
-        $response = $this->brighteApi->post(sprintf('%s/users', self::PATH), $body);
+        $response = $this->brighteApi->post(sprintf('%s/users', self::PATH), $body, '', [], self::PATH);
         
         if ($response->getStatusCode() !== StatusCodeInterface::STATUS_OK) {
             $this->logResponse(__FUNCTION__, $response);
@@ -70,10 +70,11 @@ class IdentityApi extends \BrighteCapital\Api\AbstractApi
         $body = \json_encode([
             'grant_type' => 'authorization_code',
             'code' => $code,
+            // need to revisit this as the clientId has changed to auth0
             'client_id' => $this->brighteApi->clientId
         ]);
 
-        $response = $this->brighteApi->post(sprintf('%s/token', self::PATH), $body);
+        $response = $this->brighteApi->post(sprintf('%s/token', self::PATH), $body, '', [], self::PATH);
         
         if ($response->getStatusCode() !== StatusCodeInterface::STATUS_OK) {
             $this->logResponse(__FUNCTION__, $response);
@@ -95,7 +96,7 @@ class IdentityApi extends \BrighteCapital\Api\AbstractApi
     {
         $body = \json_encode(['refreshToken' => $refreshToken]);
 
-        $response = $this->brighteApi->post(sprintf('%s/refresh', self::PATH), $body);
+        $response = $this->brighteApi->post(sprintf('%s/refresh', self::PATH), $body, '', [], self::PATH);
         
         if ($response->getStatusCode() !== StatusCodeInterface::STATUS_OK) {
             $this->logResponse(__FUNCTION__, $response);

--- a/src/PaymentApi.php
+++ b/src/PaymentApi.php
@@ -10,13 +10,13 @@ use Fig\Http\Message\StatusCodeInterface;
 class PaymentApi extends \BrighteCapital\Api\AbstractApi
 {
 
+    // reminder: need to update the Payment API audience in Auth0 from /payments to /payment for consistency
     public const PATH = '/payment';
-    public const AUDIENCE = '/payments';
 
     public function getMethod(string $methodId, int $userId): ?PaymentMethod
     {
         $params = http_build_query(compact('userId'));
-        $response = $this->brighteApi->get(sprintf('%s-methods/%s', self::PATH, $methodId), $params, [], self::AUDIENCE);
+        $response = $this->brighteApi->get(sprintf('%s-methods/%s', self::PATH, $methodId), $params, [], self::PATH);
         
         if ($response->getStatusCode() !== StatusCodeInterface::STATUS_OK) {
             $this->logResponse(__FUNCTION__, $response);

--- a/src/PaymentApi.php
+++ b/src/PaymentApi.php
@@ -10,20 +10,19 @@ use Fig\Http\Message\StatusCodeInterface;
 class PaymentApi extends \BrighteCapital\Api\AbstractApi
 {
 
-    // reminder: need to update the Payment API audience in Auth0 from /payments to /payment for consistency
     public const PATH = '/payment';
 
     public function getMethod(string $methodId, int $userId): ?PaymentMethod
     {
         $params = http_build_query(compact('userId'));
         $response = $this->brighteApi->get(sprintf('%s-methods/%s', self::PATH, $methodId), $params, [], self::PATH);
-        
+
         if ($response->getStatusCode() !== StatusCodeInterface::STATUS_OK) {
             $this->logResponse(__FUNCTION__, $response);
 
             return null;
         }
-        
+
         $result = json_decode((string) $response->getBody());
 
         $method = new PaymentMethod();

--- a/src/PaymentApi.php
+++ b/src/PaymentApi.php
@@ -11,11 +11,12 @@ class PaymentApi extends \BrighteCapital\Api\AbstractApi
 {
 
     public const PATH = '/payment';
+    public const AUDIENCE = '/payments';
 
     public function getMethod(string $methodId, int $userId): ?PaymentMethod
     {
         $params = http_build_query(compact('userId'));
-        $response = $this->brighteApi->get(sprintf('%s-methods/%s', self::PATH, $methodId), $params);
+        $response = $this->brighteApi->get(sprintf('%s-methods/%s', self::PATH, $methodId), $params, [], self::AUDIENCE);
         
         if ($response->getStatusCode() !== StatusCodeInterface::STATUS_OK) {
             $this->logResponse(__FUNCTION__, $response);

--- a/src/VendorApi.php
+++ b/src/VendorApi.php
@@ -21,7 +21,7 @@ class VendorApi extends \BrighteCapital\Api\AbstractApi
      */
     public function getVendors(): array
     {
-        $response = $this->brighteApi->get(self::PATH);
+        $response = $this->brighteApi->get(self::PATH, '', [], self::PATH);
         
         if ($response->getStatusCode() !== StatusCodeInterface::STATUS_OK) {
             $this->logResponse(__FUNCTION__, $response);
@@ -48,7 +48,7 @@ class VendorApi extends \BrighteCapital\Api\AbstractApi
 
     public function getVendor(int $vendorId): ?Vendor
     {
-        $response = $this->brighteApi->get(self::PATH . '/' . $vendorId);
+        $response = $this->brighteApi->get(self::PATH . '/' . $vendorId, '', [], self::PATH);
         
         if ($response->getStatusCode() !== StatusCodeInterface::STATUS_OK) {
             $this->logResponse(__FUNCTION__, $response);
@@ -75,7 +75,7 @@ class VendorApi extends \BrighteCapital\Api\AbstractApi
     public function getVendorFlags(int $vendorId): array
     {
         $path = sprintf("%s/%d/flags", self::PATH, $vendorId);
-        $response = $this->brighteApi->get($path);
+        $response = $this->brighteApi->get($path, '', [], self::PATH);
         if ($response->getStatusCode() !== StatusCodeInterface::STATUS_OK) {
             $this->logResponse(__FUNCTION__, $response);
 
@@ -100,7 +100,7 @@ class VendorApi extends \BrighteCapital\Api\AbstractApi
      */
     public function getVendorAgentIDs(int $vendorId): array
     {
-        $response = $this->brighteApi->get(sprintf('%s/%d/agents', self::PATH, $vendorId));
+        $response = $this->brighteApi->get(sprintf('%s/%d/agents', self::PATH, $vendorId), '', [], self::PATH);
         
         if ($response->getStatusCode() !== StatusCodeInterface::STATUS_OK) {
             $this->logResponse(__FUNCTION__, $response);
@@ -119,7 +119,7 @@ class VendorApi extends \BrighteCapital\Api\AbstractApi
      */
     public function getCategories(): array
     {
-        $response = $this->brighteApi->get('/categories');
+        $response = $this->brighteApi->get('/categories', '', [], self::PATH);
         
         if ($response->getStatusCode() !== StatusCodeInterface::STATUS_OK) {
             $this->logResponse(__FUNCTION__, $response);
@@ -143,7 +143,7 @@ class VendorApi extends \BrighteCapital\Api\AbstractApi
 
     public function getCategory(int $categoryId): ?Category
     {
-        $response = $this->brighteApi->get('/categories/' . $categoryId);
+        $response = $this->brighteApi->get('/categories/' . $categoryId, '', [], self::PATH);
 
         if ($response->getStatusCode() !== StatusCodeInterface::STATUS_OK) {
             $this->logResponse(__FUNCTION__, $response);
@@ -168,7 +168,7 @@ class VendorApi extends \BrighteCapital\Api\AbstractApi
      */
     public function getManufacturerById(int $manufacturerId): ?Manufacturer
     {
-        $response = $this->brighteApi->get("/manufacturers/" . (string) $manufacturerId);
+        $response = $this->brighteApi->get("/manufacturers/" . (string) $manufacturerId, '', [], self::PATH);
 
         if ($response->getStatusCode() !== StatusCodeInterface::STATUS_OK) {
             $this->logResponse(__FUNCTION__, $response);
@@ -211,7 +211,7 @@ class VendorApi extends \BrighteCapital\Api\AbstractApi
      */
     private function retrieveManufacturers(string $queryPath): array
     {
-        $response = $this->brighteApi->get($queryPath);
+        $response = $this->brighteApi->get($queryPath, '', [], self::PATH);
 
         if ($response->getStatusCode() !== StatusCodeInterface::STATUS_OK) {
             $this->logResponse(debug_backtrace()[1]['function'], $response);
@@ -243,7 +243,7 @@ class VendorApi extends \BrighteCapital\Api\AbstractApi
      */
     public function getVendorPromos(int $vendorId, bool $active = false): array
     {
-        $response = $this->brighteApi->get(sprintf('%s/%d/promos?active=%s', self::PATH, $vendorId, $active));
+        $response = $this->brighteApi->get(sprintf('%s/%d/promos?active=%s', self::PATH, $vendorId, $active), '', [], self::PATH);
 
         if ($response->getStatusCode() !== StatusCodeInterface::STATUS_OK) {
             $this->logResponse(__FUNCTION__, $response);


### PR DESCRIPTION
use doRequest instead of using auth0 package. This option is not constraint with PHP version.
The latest auth0 package require PHP 8, in which it will have dependancy issues with older PHP version repos (e.g. Portal 7.1)

Related PR:
https://github.com/brighte-labs/slim-core/pull/8